### PR TITLE
This addresses the issue where when a pk is not found, a 500 is thrown

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,9 @@
+2016.2.26 2016.02.26
+====================
+----
+
+* Fix: Adding error handling for any tinker that tries to insert random pk.
+
 2014.9.26 2014.09.26
 ====================
 ----

--- a/django_databrowse/__init__.py
+++ b/django_databrowse/__init__.py
@@ -4,4 +4,4 @@ from django_databrowse.sites import (DatabrowsePlugin, ModelDatabrowse,
 __ALL__ = [DatabrowsePlugin, ModelDatabrowse,
            DefaultModelDatabrowse, site]
 
-__version__ = (2014, 9, 26)
+__version__ = (2016, 2, 26)

--- a/django_databrowse/plugins/objects.py
+++ b/django_databrowse/plugins/objects.py
@@ -22,7 +22,7 @@ class ObjectDetailPlugin(DatabrowsePlugin):
         except ObjectDoesNotExist, e:
             raise http.Http404('Id not found')
         except ValueError, e:
-            raise http.Http404('Invalid format key provide')
+            raise http.Http404('Invalid format key provided')
         return render_to_response(
             'databrowse/object_detail.html',
             {

--- a/django_databrowse/plugins/objects.py
+++ b/django_databrowse/plugins/objects.py
@@ -1,4 +1,5 @@
 from django import http
+from django.core.exceptions import ObjectDoesNotExist
 from django_databrowse.datastructures import EasyModel
 from django_databrowse.sites import DatabrowsePlugin
 from django.shortcuts import render_to_response
@@ -16,7 +17,12 @@ class ObjectDetailPlugin(DatabrowsePlugin):
             model_databrowse.site,
             model_databrowse.model
         )
-        obj = easy_model.object_by_pk(url)
+        try:
+            obj = easy_model.object_by_pk(url)
+        except ObjectDoesNotExist, e:
+            raise http.Http404('Id not found')
+        except ValueError, e:
+            raise http.Http404('Invalid format key provide')
         return render_to_response(
             'databrowse/object_detail.html',
             {

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='django-databrowse',
-    version='2014.9.26',
+    version='2016.2.26',
     packages=['django_databrowse', 'django_databrowse.plugins'],
     package_dir={'django_databrowse': 'django_databrowse'},
     package_data={


### PR DESCRIPTION
We had some people screen scraping databrowse and querying invalid ids.  Instead of throwing 404, this throws an unhandled error and appears as a 500.  For the ValueError, this is for when someone attempts to insert a string for an int, although you can argue it a bad request, 404 makes more sense.

This was tested against django 1.6