### PR TITLE
Add RequestContext to render_to_response calls

### DIFF
--- a/django_databrowse/plugins/calendars.py
+++ b/django_databrowse/plugins/calendars.py
@@ -3,6 +3,7 @@ from django.db import models
 from django_databrowse.datastructures import EasyModel
 from django_databrowse.sites import DatabrowsePlugin
 from django.shortcuts import render_to_response
+from django.template import RequestContext
 from django.utils.text import capfirst
 from django.utils.encoding import force_unicode
 from django.utils.safestring import mark_safe
@@ -114,7 +115,7 @@ class CalendarPlugin(DatabrowsePlugin):
                 'root_url': self.site.root_url,
                 'model': easy_model,
                 'field_list': field_list
-            }
+            }, context_instance=RequestContext(request)
         )
 
     def calendar_view(self, request, field, year=None, month=None, day=None):

--- a/django_databrowse/plugins/fieldchoices.py
+++ b/django_databrowse/plugins/fieldchoices.py
@@ -3,6 +3,7 @@ from django.db import models
 from django_databrowse.datastructures import EasyModel
 from django_databrowse.sites import DatabrowsePlugin
 from django.shortcuts import render_to_response
+from django.template import RequestContext
 from django.utils.text import capfirst
 from django.utils.encoding import smart_str, force_unicode
 from django.utils.safestring import mark_safe
@@ -89,7 +90,7 @@ class FieldChoicePlugin(DatabrowsePlugin):
                 'root_url': self.site.root_url,
                 'model': easy_model,
                 'field_list': field_list
-            }
+            }, context_instance=RequestContext(request)
         )
 
     def field_view(self, request, field, value=None):
@@ -131,7 +132,7 @@ class FieldChoicePlugin(DatabrowsePlugin):
                     'value': value,
                     'object_list': obj_list_page,
                     'items_per_page': items_per_page,
-                }
+                }, context_instance=RequestContext(request)
             )
 
         return render_to_response(
@@ -142,5 +143,5 @@ class FieldChoicePlugin(DatabrowsePlugin):
                 'field': easy_field,
                 'object_list': obj_list_page,
                 'items_per_page': items_per_page,
-            }
+            }, context_instance=RequestContext(request)
         )

--- a/django_databrowse/plugins/objects.py
+++ b/django_databrowse/plugins/objects.py
@@ -3,6 +3,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django_databrowse.datastructures import EasyModel
 from django_databrowse.sites import DatabrowsePlugin
 from django.shortcuts import render_to_response
+from django.template import RequestContext
 import urlparse
 
 class ObjectDetailPlugin(DatabrowsePlugin):
@@ -28,5 +29,5 @@ class ObjectDetailPlugin(DatabrowsePlugin):
             {
                 'object': obj,
                 'root_url': model_databrowse.site.root_url
-            }
+            }, context_instance=RequestContext(request)
         )

--- a/django_databrowse/sites.py
+++ b/django_databrowse/sites.py
@@ -6,6 +6,7 @@ except ImportError, e:
     from django.db.models import get_model
 
 from django.shortcuts import render_to_response
+from django.template import RequestContext
 from django.utils.safestring import mark_safe
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 
@@ -106,7 +107,7 @@ class ModelDatabrowse(object):
                 'plugin_html': html_snippets,
                 'object_list': obj_list_page,
                 'items_per_page': items_per_page,
-            }
+            }, context_instance=RequestContext(request)
         )
 
 
@@ -166,7 +167,8 @@ class DatabrowseSite(object):
         m_list = [EasyModel(self, m) for m in self.registry.keys()]
         return render_to_response(
             'databrowse/homepage.html',
-            {'model_list': m_list, 'root_url': self.root_url}
+            {'model_list': m_list, 'root_url': self.root_url},
+            context_instance=RequestContext(request)
         )
 
     def model_page(self, request, app_label, model_name, rest_of_url=None):

--- a/django_databrowse/views.py
+++ b/django_databrowse/views.py
@@ -1,5 +1,6 @@
 from django.http import Http404
 from django.shortcuts import render_to_response
+from django.template import RequestContext
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 
 ###########
@@ -10,7 +11,8 @@ def choice_list(request, app_label, model_name, field_name, models):
     m, f = lookup_field(app_label, model_name, field_name, models)
     return render_to_response(
         'databrowse/choice_list.html',
-        {'model': m, 'field': f}
+        {'model': m, 'field': f},
+        context_instance=RequestContext(request)
     )
 
 def choice_detail(request, app_label, model_name, field_name,
@@ -47,5 +49,5 @@ def choice_detail(request, app_label, model_name, field_name,
             'value': label,
             'object_list': obj_list_page,
             'items_per_page': items_per_page,
-        }
+        }, context_instance=RequestContext(request)
     )


### PR DESCRIPTION
This PR updates all render_to_response calls with a RequestContext.

Providing a RequestContext to render_to_response ensures that all configured context processors are invoked during template rendering. See Django Doc, [Using Request Context](https://docs.djangoproject.com/en/1.10/ref/templates/api/#using-requestcontext) for more info.

 

